### PR TITLE
ハードコーディングされた`delay`呼び出しをリファクタリングし、より堅牢なポーリングメカニズムである`Utils.waitFor`ユー…

### DIFF
--- a/Modules/NetworkManager.applescript
+++ b/Modules/NetworkManager.applescript
@@ -20,4 +20,9 @@ script NetworkManager
 		return shell_result's success
 	end isPortInUse
 
+	on isOllamaApiReady(host, port)
+		set command to "curl --silent --fail http://" & host & ":" & port
+		set shell_result to parent's Utils's executeShell(command)
+		return shell_result's success
+	end isOllamaApiReady
 end script

--- a/Modules/TerminalManager.applescript
+++ b/Modules/TerminalManager.applescript
@@ -9,15 +9,33 @@ script TerminalManager
 		tell application "Terminal"
 			activate
 			set current_window to parent_window
+			set initial_tab_count to count of tabs of current_window
+
 			-- ウィンドウを選択してからCmd+Tで新しいタブを作成
 			set selected of current_window to true
 			tell application "System Events"
 				keystroke "t" using command down
 			end tell
-			delay 0.5
-			-- 新しいタブでコマンドを実行
-			do script command in front window
-			return selected tab of front window
+
+			-- 新しいタブが実際に開くまで待機
+			script tab_checker
+				property target_window : current_window
+				property original_count : initial_tab_count
+				on check()
+					return (count of tabs of target_window) > original_count
+				end check
+			end script
+			set wait_successful to parent's Utils's waitFor(tab_checker, 2, 0.2, "新しいターミナルタブの作成に失敗しました。")
+
+			if wait_successful then
+				-- 新しいタブでコマンドを実行
+				do script command in front window
+				return selected tab of front window
+			else
+				-- タイムアウトした場合、エラーを報告
+				parent's Utils's showError("タブ作成エラー", "新しいターミナルタブを開けませんでした。", stop)
+				error "Failed to create a new tab."
+			end if
 		end tell
 	end openNewTerminalTab
 


### PR DESCRIPTION
…ティリティに置き換えました。

- **`OllamaManager`**: サーバーポートが検出された後の単純な遅延の代わりに、スクリプトは2段階の待機を実行するようになりました。まずポートが開くのを待ち、次に応答があるまでOllama APIをアクティブにポーリングします。この目的のために、新しい`isOllamaApiReady`関数を`NetworkManager`に追加しました。これにより、サーバーがリクエストを完全に受け入れる準備ができたときにのみチャットコマンドが実行されるようになります。

- **`TerminalManager`**: 新しいターミナルタブを作成する際に使用されていた固定の`delay`を置き換えました。スクリプトは、作成コマンドの前後でタブの数を確認し、新しいタブが実際に表示されるまで待機するようになりました。これにより、タブが受信準備が整う前にコマンドが送信される可能性のある問題が防止されます。

これらの変更により、システムのパフォーマンスやサーバーの起動時間の変動に対するアプリケーションの回復力が高まります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Ollama APIの準備状況を確認する機能を追加しました。

* **バグ修正**
  * ターミナルで新しいタブを開く際、タブが確実に作成されたことを確認してからコマンドを実行するよう改善しました。
  * Ollamaサーバー起動時、ポートの待機に加えAPI応答の確認も行うようになり、エラー表示がより具体的になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->