### PR TITLE
Refactor AppleScript modules for improved modularity

### DIFF
--- a/Modules/WindowManager.applescript
+++ b/Modules/WindowManager.applescript
@@ -1,17 +1,14 @@
-property OLLAMA_PORT : 0
-property MODEL_NAME : ""
-
-on generateWindowTitle(wifi_ip, sequence_number, title_type)
+on generateWindowTitle(wifi_ip, sequence_number, title_type, ollama_port, model_name)
 	if title_type is "server" then
-		return "Ollama Server #" & sequence_number & " [" & wifi_ip & ":" & OLLAMA_PORT & "]"
+		return "Ollama Server #" & sequence_number & " [" & wifi_ip & ":" & ollama_port & "]"
 	else if title_type is "chat" then
-		return "Ollama Chat #" & sequence_number & " [" & wifi_ip & ":" & OLLAMA_PORT & "] (" & MODEL_NAME & ")"
+		return "Ollama Chat #" & sequence_number & " [" & wifi_ip & ":" & ollama_port & "] (" & model_name & ")"
 	end if
 end generateWindowTitle
 
-on getMaxSequenceNumber(wifi_ip)
+on getMaxSequenceNumber(wifi_ip, ollama_port)
 	set max_seq to 0
-	set expected_server_pattern to "[" & wifi_ip & ":" & OLLAMA_PORT & "]"
+	set expected_server_pattern to "[" & wifi_ip & ":" & ollama_port & "]"
 	try
 		tell application "Terminal"
 			repeat with w in windows
@@ -47,11 +44,11 @@ on getMaxSequenceNumber(wifi_ip)
 	return max_seq
 end getMaxSequenceNumber
 
-on findLatestServerWindow(wifi_ip)
+on findLatestServerWindow(wifi_ip, ollama_port)
 	set max_seq to 0
 	set latest_window to missing value
 	set latest_sequence to missing value
-	set expected_server_pattern to "[" & wifi_ip & ":" & OLLAMA_PORT & "]"
+	set expected_server_pattern to "[" & wifi_ip & ":" & ollama_port & "]"
 
 	try
 		tell application "Terminal"

--- a/main.applescript
+++ b/main.applescript
@@ -3,8 +3,6 @@
 -- ==========================================
 property MODEL_NAME : "gemma3:latest"
 property OLLAMA_PORT : 55764
-property SERVER_STARTUP_TIMEOUT : 30
-property SERVER_CHECK_INTERVAL : 0.1
 
 -- ==========================================
 -- Module Loading
@@ -15,31 +13,24 @@ set script_path to path to me
 set script_folder to (script_path as text) & "::"
 
 -- Load the modules using the robust `load script` command.
-set Net to load script file (script_folder & "Modules:Network.applescript")
-set Win to load script file (script_folder & "Modules:WindowManager.applescript")
-set Server to load script file (script_folder & "Modules:ServerManager.applescript")
+set Network to load script file (script_folder & "Modules:Network.applescript")
+set WindowManager to load script file (script_folder & "Modules:WindowManager.applescript")
+set ServerManager to load script file (script_folder & "Modules:ServerManager.applescript")
 
 -- ==========================================
 -- Dependency Injection
 -- ==========================================
--- Inject constants into the WindowManager module.
-set Win's OLLAMA_PORT to OLLAMA_PORT
-set Win's MODEL_NAME to MODEL_NAME
-
--- Inject constants and other modules into the ServerManager module.
-set Server's OLLAMA_PORT to OLLAMA_PORT
-set Server's MODEL_NAME to MODEL_NAME
-set Server's SERVER_STARTUP_TIMEOUT to SERVER_STARTUP_TIMEOUT
-set Server's SERVER_CHECK_INTERVAL to SERVER_CHECK_INTERVAL
-set Server's Net to Net
-set Server's Win to Win
+-- Inject modules into the ServerManager module.
+set ServerManager's parent to me
+set ServerManager's Network to Network
+set ServerManager's WindowManager to WindowManager
 
 -- ==========================================
 -- Main Execution
 -- ==========================================
 try
-	set wifi_ip to Net's getWifiIP()
-	if Net's isPortInUse(OLLAMA_PORT) then
+	set wifi_ip to Network's getWifiIP()
+	if Network's isPortInUse(OLLAMA_PORT) then
 		my handleExistingServer(wifi_ip)
 	else
 		my handleNewServer(wifi_ip)
@@ -52,23 +43,23 @@ end try
 -- メインフロー制御関数群
 -- ==========================================
 on handleExistingServer(wifi_ip)
-	set server_info to Win's findLatestServerWindow(wifi_ip)
+	set server_info to WindowManager's findLatestServerWindow(wifi_ip, OLLAMA_PORT)
 	set server_window to server_info's window
 	set sequence_number to server_info's sequence
 	if server_window is not missing value then
-		Server's executeOllamaModel(server_window, wifi_ip, sequence_number)
+		ServerManager's executeOllamaModel(server_window, wifi_ip, sequence_number, MODEL_NAME, OLLAMA_PORT)
 	else
 		my handleNewServer(wifi_ip)
 	end if
 end handleExistingServer
 
 on handleNewServer(wifi_ip)
-	set server_info to Server's startOllamaServer(wifi_ip)
+	set server_info to ServerManager's startOllamaServer(wifi_ip, OLLAMA_PORT, MODEL_NAME)
 	set server_window to server_info's window
 	set sequence_number to server_info's sequence
-	if Server's waitForServer() then
+	if ServerManager's waitForServer(OLLAMA_PORT) then
 		delay 1 -- サーバー完全起動のための待機
-		Server's executeOllamaModel(server_window, wifi_ip, sequence_number)
+		ServerManager's executeOllamaModel(server_window, wifi_ip, sequence_number, MODEL_NAME, OLLAMA_PORT)
 	else
 		log "起動失敗: サーバーの起動に失敗しました。"
 	end if


### PR DESCRIPTION
This commit refactors the AppleScript project to improve modularity and maintainability.

The following changes were made:
- Server-specific configuration properties (`SERVER_STARTUP_TIMEOUT` and `SERVER_CHECK_INTERVAL`) were moved from `main.applescript` into the `ServerManager.applescript` module where they are used.
- Module variable names in `main.applescript` were changed from abbreviations to full, descriptive names (`Net` -> `Network`, `Win` -> `WindowManager`, `Server` -> `ServerManager`).
- Dependency injection of constants was removed. Instead, necessary values are passed as function arguments between modules, reducing coupling.
- The `parent` property is now used to establish a clearer inheritance relationship between `main.applescript` and the `ServerManager` module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * グローバル定数の使用を廃止し、必要な値（ポート番号やモデル名など）を関数の引数として明示的に渡す方式に変更しました。
  * モジュール名や変数名をより分かりやすくリネームしました。
  * 内部処理の整理により、依存関係の注入方法を簡素化しました。

* **その他**
  * 表示や動作に直接の影響はありませんが、今後の保守性や拡張性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->