### PR TITLE
Refactor ServerManager to remove direct dependencies on other modules.

### DIFF
--- a/Modules/ServerManager.applescript
+++ b/Modules/ServerManager.applescript
@@ -4,11 +4,7 @@ property SERVER_STARTUP_TIMEOUT : 30
 property SERVER_CHECK_INTERVAL : 0.1
 
 -- Properties for other modules, inherited from the parent script
-property parent : me
-property Network : missing value
-property WindowManager : missing value
-
-on waitForServer(ollama_port)
+on waitForServer(ollama_port, Network)
 	set elapsed to 0
 	repeat until Network's isPortInUse(ollama_port)
 		delay SERVER_CHECK_INTERVAL
@@ -49,7 +45,7 @@ on createNewTerminalWindow(command)
 	end tell
 end createNewTerminalWindow
 
-on startOllamaServer(wifi_ip, ollama_port, model_name)
+on startOllamaServer(wifi_ip, ollama_port, model_name, WindowManager)
 	set next_seq to (WindowManager's getMaxSequenceNumber(wifi_ip, ollama_port) + 1)
 	set window_title to WindowManager's generateWindowTitle(wifi_ip, next_seq, "server", ollama_port, model_name)
 	set command to "OLLAMA_HOST=" & wifi_ip & ":" & ollama_port & " ollama serve"
@@ -60,7 +56,7 @@ on startOllamaServer(wifi_ip, ollama_port, model_name)
 	return {window:new_window, sequence:next_seq}
 end startOllamaServer
 
-on validateServerWindow(target_window, wifi_ip, sequence_number, ollama_port, model_name)
+on validateServerWindow(target_window, wifi_ip, sequence_number, ollama_port, model_name, WindowManager)
 	if target_window is missing value then
 		set msg to "Ollamaサーバーのウィンドウが見つかりませんでした。"
 		set details to "検索条件: IP=" & wifi_ip & ", PORT=" & ollama_port & return & "期待ウィンドウ名: " & WindowManager's generateWindowTitle(wifi_ip, sequence_number, "server", ollama_port, model_name)
@@ -77,8 +73,8 @@ on validateServerWindow(target_window, wifi_ip, sequence_number, ollama_port, mo
 	end if
 end validateServerWindow
 
-on executeOllamaModel(target_window, wifi_ip, sequence_number, model_name, ollama_port)
-	my validateServerWindow(target_window, wifi_ip, sequence_number, ollama_port, model_name)
+on executeOllamaModel(target_window, wifi_ip, sequence_number, model_name, ollama_port, WindowManager)
+	my validateServerWindow(target_window, wifi_ip, sequence_number, ollama_port, model_name, WindowManager)
 
 	set command to "OLLAMA_HOST=http://" & wifi_ip & ":" & ollama_port & " ollama run " & model_name
 	set new_tab to my openNewTerminalTab(target_window, command)

--- a/main.applescript
+++ b/main.applescript
@@ -18,13 +18,6 @@ set WindowManager to load script file (script_folder & "Modules:WindowManager.ap
 set ServerManager to load script file (script_folder & "Modules:ServerManager.applescript")
 
 -- ==========================================
--- Dependency Injection
--- ==========================================
--- Inject modules into the ServerManager module.
-set ServerManager's parent to me
-set ServerManager's Network to Network
-set ServerManager's WindowManager to WindowManager
-
 -- ==========================================
 -- Main Execution
 -- ==========================================
@@ -47,19 +40,19 @@ on handleExistingServer(wifi_ip)
 	set server_window to server_info's window
 	set sequence_number to server_info's sequence
 	if server_window is not missing value then
-		ServerManager's executeOllamaModel(server_window, wifi_ip, sequence_number, MODEL_NAME, OLLAMA_PORT)
+		ServerManager's executeOllamaModel(server_window, wifi_ip, sequence_number, MODEL_NAME, OLLAMA_PORT, WindowManager)
 	else
 		my handleNewServer(wifi_ip)
 	end if
 end handleExistingServer
 
 on handleNewServer(wifi_ip)
-	set server_info to ServerManager's startOllamaServer(wifi_ip, OLLAMA_PORT, MODEL_NAME)
+	set server_info to ServerManager's startOllamaServer(wifi_ip, OLLAMA_PORT, MODEL_NAME, WindowManager)
 	set server_window to server_info's window
 	set sequence_number to server_info's sequence
-	if ServerManager's waitForServer(OLLAMA_PORT) then
+	if ServerManager's waitForServer(OLLAMA_PORT, Network) then
 		delay 1 -- サーバー完全起動のための待機
-		ServerManager's executeOllamaModel(server_window, wifi_ip, sequence_number, MODEL_NAME, OLLAMA_PORT)
+		ServerManager's executeOllamaModel(server_window, wifi_ip, sequence_number, MODEL_NAME, OLLAMA_PORT, WindowManager)
 	else
 		log "起動失敗: サーバーの起動に失敗しました。"
 	end if


### PR DESCRIPTION
In accordance with your request to reduce inter-module dependencies, I have removed the dependency injection mechanism from `main.applescript` that was used to provide the `Network` and `WindowManager` modules to `ServerManager`.

I made the following changes:
- Removed the `Network` and `WindowManager` properties from `ServerManager.applescript`.
- Updated the function signatures in `ServerManager.applescript` to accept `Network` and `WindowManager` modules as parameters where needed.
- Updated `main.applescript` to pass the required modules as arguments when calling functions in `ServerManager`.

This results in a more loosely coupled design where data and module dependencies are passed explicitly through function calls, making the relationships between modules clearer and easier to maintain.